### PR TITLE
fix: remove duplicated 'Option 2: CLI Tool' heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ pnpm --filter @smyt/web dev
 
 ### Option 2: CLI Tool
 
-### Option 2: CLI Tool
-
 ```bash
 # Install dependencies
 pnpm install


### PR DESCRIPTION
Fixes #3

## What

Removed the duplicated `### Option 2: CLI Tool` heading in README.md (lines 39-41).

## Before
```markdown
### Option 2: CLI Tool

### Option 2: CLI Tool
```

## After
```markdown
### Option 2: CLI Tool
```

One-line fix 🧹