### PR TITLE
fix: remove duplicated 'Option 2: CLI Tool' heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ pnpm --filter @smyt/web dev
 
 ### Option 2: CLI Tool
 
-### Option 2: CLI Tool
-
 ```bash
 # Install dependencies
 pnpm install


### PR DESCRIPTION
## Description
This PR removes a duplicated 'Option 2: CLI Tool' heading in the README.md file.

## Why
The heading was accidentally repeated, causing a minor formatting issue in the documentation.

## How
Removed the extra line containing the redundant heading.

Fixes #3