### PR TITLE
docs: clarify which .env.example belongs to which package

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,10 @@
+# ==========================================
+# ROOT .env — for CLI tool (packages/cli)
+# ==========================================
+# This file is used by the CLI tool only.
+# For the web dashboard, see: packages/web/.env.example
+# ==========================================
+
 # GitHub OAuth Client ID (for Device Flow authentication - REQUIRED)
 # Create OAuth App at: https://github.com/settings/applications/new
 # See OAUTH_SETUP.md for detailed setup instructions

--- a/packages/web/.env.example
+++ b/packages/web/.env.example
@@ -1,3 +1,10 @@
+# ==========================================
+# WEB .env — for web dashboard (packages/web)
+# ==========================================
+# This file is used by the Next.js web dashboard only.
+# For the CLI tool, see the root .env.example
+# ==========================================
+
 # GitHub OAuth App credentials
 # Create OAuth App at: https://github.com/settings/applications/new
 # Authorization callback URL: http://localhost:3000/api/auth/callback (for development)


### PR DESCRIPTION
Fixes #1

Added header comments to both .env.example files explaining their scope