### PR TITLE
feat: add graceful rate limit handling to GitHub fetcher

### DIFF
--- a/packages/core/src/fetcher.ts
+++ b/packages/core/src/fetcher.ts
@@ -18,6 +18,67 @@ async function pLimit<T>(tasks: (() => Promise<T>)[], limit: number): Promise<T[
   return results;
 }
 
+/**
+ * Check if an error is a GitHub rate limit error (HTTP 403 or 429).
+ * Returns the reset timestamp (epoch seconds) if available, or null.
+ */
+function getRateLimitReset(error: unknown): number | null {
+  if (!error || typeof error !== 'object' || !('status' in error)) {
+    return null;
+  }
+  const status = (error as { status: number }).status;
+  if (status !== 403 && status !== 429) {
+    return null;
+  }
+  const headers = (error as { response?: { headers?: Record<string, string> } }).response?.headers;
+  const remaining = headers?.['x-ratelimit-remaining'];
+  if (remaining === '0' || status === 429) {
+    const reset = headers?.['x-ratelimit-reset'];
+    return reset ? Number(reset) : null;
+  }
+  return null;
+}
+
+/**
+ * Sleep for the given number of milliseconds.
+ */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    globalThis.setTimeout(resolve, ms);
+  });
+}
+
+/**
+ * Execute a GitHub API call with rate-limit awareness.
+ * If rate-limited, waits until the reset time and retries (up to maxRetries).
+ */
+async function withRateLimitRetry<T>(
+  fn: () => Promise<T>,
+  label: string = 'API call',
+  maxRetries: number = 2
+): Promise<T> {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error: unknown) {
+      const resetEpoch = getRateLimitReset(error);
+      if (resetEpoch !== null && attempt < maxRetries) {
+        const now = Math.floor(Date.now() / 1000);
+        const waitSeconds = Math.max(resetEpoch - now, 1) + 1; // +1s buffer
+        console.warn(
+          `⚠️  Rate limited on ${label}. ` +
+            `Waiting ${waitSeconds}s until reset (attempt ${attempt + 1}/${maxRetries})...`
+        );
+        await sleep(waitSeconds * 1000);
+        continue;
+      }
+      throw error;
+    }
+  }
+  // Should never reach here, but satisfy TypeScript
+  throw new Error(`Rate limit retries exhausted for ${label}`);
+}
+
 export class GitHubFetcher {
   private octokit: Octokit;
 
@@ -33,23 +94,21 @@ export class GitHubFetcher {
     repo: string,
     activeDaysThreshold: number = 30
   ): Promise<Branch[]> {
-    const { data: branches } = await this.octokit.repos.listBranches({
-      owner,
-      repo,
-      per_page: 100,
-    });
+    const { data: branches } = await withRateLimitRetry(
+      () => this.octokit.repos.listBranches({ owner, repo, per_page: 100 }),
+      `listBranches(${owner}/${repo})`
+    );
 
     const now = new Date();
     const threshold = activeDaysThreshold * 24 * 60 * 60 * 1000;
 
-    // Fetch commit details with concurrency limit to avoid API rate limits
+    // Fetch commit details with concurrency limit + rate-limit retry
     const tasks = branches.map((branch) => async () => {
       try {
-        const { data: commit } = await this.octokit.repos.getCommit({
-          owner,
-          repo,
-          ref: branch.commit.sha,
-        });
+        const { data: commit } = await withRateLimitRetry(
+          () => this.octokit.repos.getCommit({ owner, repo, ref: branch.commit.sha }),
+          `getCommit(${branch.name})`
+        );
 
         const commitDate = new Date(commit.commit.author?.date || now);
         const isActive = now.getTime() - commitDate.getTime() < threshold;
@@ -61,7 +120,15 @@ export class GitHubFetcher {
           author: commit.commit.author?.name || 'Unknown',
           isActive,
         };
-      } catch {
+      } catch (error: unknown) {
+        const resetEpoch = getRateLimitReset(error);
+        if (resetEpoch !== null) {
+          const resetTime = new Date(resetEpoch * 1000).toLocaleTimeString();
+          console.warn(
+            `⚠️  Rate limited while fetching branch "${branch.name}". ` +
+              `Rate limit resets at ${resetTime}. Skipping branch.`
+          );
+        }
         // If we can't fetch commit details, mark as inactive
         return {
           name: branch.name,
@@ -89,12 +156,10 @@ export class GitHubFetcher {
   ): Promise<CommitInfo[]> {
     try {
       // Get commits that are in branch but not in base
-      const { data: comparison } = await this.octokit.repos.compareCommits({
-        owner,
-        repo,
-        base: baseBranch,
-        head: branch,
-      });
+      const { data: comparison } = await withRateLimitRetry(
+        () => this.octokit.repos.compareCommits({ owner, repo, base: baseBranch, head: branch }),
+        `compareCommits(${branch})`
+      );
 
       return comparison.commits.map((commit) => ({
         sha: commit.sha,
@@ -120,12 +185,10 @@ export class GitHubFetcher {
     branch: string
   ): Promise<PullRequest | undefined> {
     try {
-      const { data: prs } = await this.octokit.pulls.list({
-        owner,
-        repo,
-        head: `${owner}:${branch}`,
-        state: 'open',
-      });
+      const { data: prs } = await withRateLimitRetry(
+        () => this.octokit.pulls.list({ owner, repo, head: `${owner}:${branch}`, state: 'open' }),
+        `listPRs(${branch})`
+      );
 
       if (prs.length === 0) return undefined;
 
@@ -163,15 +226,17 @@ export class GitHubFetcher {
     baseBranch: string = 'main'
   ): Promise<string> {
     try {
-      const { data: comparison } = await this.octokit.repos.compareCommits({
-        owner,
-        repo,
-        base: baseBranch,
-        head: branch,
-        mediaType: {
-          format: 'diff',
-        },
-      });
+      const { data: comparison } = await withRateLimitRetry(
+        () =>
+          this.octokit.repos.compareCommits({
+            owner,
+            repo,
+            base: baseBranch,
+            head: branch,
+            mediaType: { format: 'diff' },
+          }),
+        `fetchDiff(${branch})`
+      );
 
       return comparison as unknown as string;
     } catch (error) {


### PR DESCRIPTION
## Summary

Add rate-limit awareness to all GitHub API calls in the core fetcher.

## Changes

- **`withRateLimitRetry()` wrapper** — detects HTTP 403/429 rate limit responses, reads `X-RateLimit-Reset` header, waits until reset, and retries (up to 2 attempts)
- **All Octokit calls wrapped** — `listBranches`, `getCommit`, `compareCommits`, `listPRs`, and `fetchDiff`
- **Clear warning messages** — logs reset time when rate limited so users know what's happening
- **Graceful degradation** — branches that fail after retries are skipped (marked inactive) instead of crashing the whole analysis

## Before

Users hit cryptic errors when analyzing repos with many branches. No indication of rate limiting.

## After

```
⚠️  Rate limited on getCommit(feature-branch). Waiting 42s until reset (attempt 1/2)...
```

Auto-waits and retries. If still limited, skips gracefully.

Closes #4